### PR TITLE
修复 v2.0.0-beta.43 的兼容性问题

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -4,6 +4,7 @@ let description = 'Online manual for sustecher'
 let color = '#49BF7C'
 let author = 'sustech.online'
 // const {path} = require('@vuepress/utils')
+const { defaultTheme } = require('vuepress')
 
 module.exports = {
     locales: {
@@ -130,7 +131,7 @@ module.exports = {
         '@vuepress/plugin-git',
         '@vuepress/plugin-toc',
     ],
-    themeConfig: {
+    theme: defaultTheme({
         navbar: [
             {text: '主页', link: '/'},
             {text: '快讯网', link: 'https://daily.sustech.online/'},
@@ -139,15 +140,14 @@ module.exports = {
             {text: '站点帮助', link: '/site-help/'},
         ],
         repo: 'sustech-cra/sustech-online-ng',
+        repoLabel: '在Github上查看',
         docsRepo: 'sustech-cra/sustech-online-ng',
         docsDir: 'docs',
-        repoLabel: '在Github上查看',
         editLinkText: '一起完善这本手册！',
         lastUpdatedText: '上次更新',
         contributorsText: '贡献者',
         editLinks: true,
         docsBranch: 'master',
-        smoothScroll: true,
         sidebarDepth: 2,
         sidebar: [
             '/',
@@ -188,5 +188,5 @@ module.exports = {
             },
             '/surroundings/',
         ]
-    }
+      }),
 }


### PR DESCRIPTION
直接用 next 还是有点危险

已经回滚了：https://github.com/SUSTech-CRA/sustech-online-ng/commit/c2ba6b4709ef9262b22becfc16806cae61e4c478

解决兼容问题：

- [x] 侧边栏缺少条目
- [ ] 搜索框不见了 
- [ ] 访问没有在sidebar中索引的页面，右上方的按钮消失。