### PR TITLE
nikebus移动端适配

### DIFF
--- a/docs/.vuepress/components/BusChartVue.vue
+++ b/docs/.vuepress/components/BusChartVue.vue
@@ -80,8 +80,8 @@ export default {
       grid: [{
         top: '10%',
         bottom: '0%',
-        left: '0%',
-        right: '10%',
+        left: '26px',
+        right: '14px',
       }],
       yAxis: [{
         inverse: true,
@@ -132,6 +132,7 @@ export default {
         label: {
           fontSize: 11,
           show: true,
+          color: '#000',
           fontWeight: 'bold',
           position: 'right',
           distance: -5,


### PR DESCRIPTION
1.为nikebus的echarts左右定义像素距离，确保在各移动端文字能够显示完整
2.车牌字体颜色显示不对，指定车牌字体颜色为黑色，试试看能不能解决问题