### PR TITLE
nikebus车牌字体适配深色模式

### DIFF
--- a/docs/.vuepress/components/BusChartVue.vue
+++ b/docs/.vuepress/components/BusChartVue.vue
@@ -133,6 +133,8 @@ export default {
           fontSize: 11,
           show: true,
           color: '#000',
+          textBorderColor:'#fff',
+          textBorderWidth:2,
           fontWeight: 'bold',
           position: 'right',
           distance: -5,


### PR DESCRIPTION
为字体加上白色描边