### PR TITLE
更新公众号信息

### DIFF
--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -37,7 +37,7 @@ img.wx-qr.medium-zoom-image{ min-width: 100px; max-width: 150px; }
 |   名称   |   网址/微信号    |                            二维码                            |
 | :------: | :--------------: | :----------------------------------------------------------: |
 | 致仁书院 | gh_67d6ddcf1965  | <img src="https://open.weixin.qq.com/qr/code?username=gh_67d6ddcf1965#.jpg" class="wx-qr medium-zoom-image"> |
-| 树仁书院 |   sustcshuren    | <img src="https://open.weixin.qq.com/qr/code?username=sustcshuren#.jpg" class="wx-qr medium-zoom-image"> |
+| 树仁书院 |   gh_d955765a8692    | <img src="https://open.weixin.qq.com/qr/code?username=gh_d955765a8692#.jpg" class="wx-qr medium-zoom-image"> |
 | 致诚书院 | SUSTech_ZhiCheng | <img src="https://open.weixin.qq.com/qr/code?username=SUSTech_ZhiCheng#.jpg" class="wx-qr medium-zoom-image"> |
 | 树德书院 |   sustc_shude    | <img src="https://open.weixin.qq.com/qr/code?username=sustc_shude#.jpg" class="wx-qr medium-zoom-image"> |
 | 树礼书院 |     SUSTCsl      | <img src="https://open.weixin.qq.com/qr/code?username=SUSTCsl#.jpg" class="wx-qr medium-zoom-image"> |
@@ -50,13 +50,12 @@ img.wx-qr.medium-zoom-image{ min-width: 100px; max-width: 150px; }
 | :----------------------: | :-------------: | :----------------------------------------------------------: |
 |    南方科技大学图书馆    |   SUSTechLib    | <img src="https://open.weixin.qq.com/qr/code?username=SUSTechLib#.jpg" class="wx-qr medium-zoom-image"> |
 | 南科大语言中心SUSTechCLE |   SUSTechCLE    | <img src="https://open.weixin.qq.com/qr/code?username=SUSTechCLE#.jpg" class="wx-qr medium-zoom-image"> |
-| 南方科技大学教学信息平台 |    SUSTC_TAO    | <img src="https://open.weixin.qq.com/qr/code?username=SUSTC_TAO#.jpg" class="wx-qr medium-zoom-image"> |
-| 南科大招生 | SUSTech_zsb | <img src="https://open.weixin.qq.com/qr/code?username=SUSTech_zsb#.jpg" class="wx-qr medium-zoom-image"> |
+| 南方科技大学教学信息平台 |    SUSTech_TAO    | <img src="https://open.weixin.qq.com/qr/code?username=SUSTech_TAO#.jpg" class="wx-qr medium-zoom-image"> |
+| 南科大招生 | gotosustech | <img src="https://open.weixin.qq.com/qr/code?username=gotosustech#.jpg" class="wx-qr medium-zoom-image"> |
 | 南科大学生事务中心 |    gh_5f30bf8a4656    | <img src="https://open.weixin.qq.com/qr/code?username=gh_5f30bf8a4656#.jpg" class="wx-qr medium-zoom-image"> |
-|    南科大就业指导中心    | gh_e9b225f6358f | <img src="https://open.weixin.qq.com/qr/code?username=gh_e9b225f6358f#.jpg" class="wx-qr medium-zoom-image"> |
-|    南科大国际合作部    | gh_d466c32bf2d7 | <img src="https://open.weixin.qq.com/qr/code?username=gh_d466c32bf2d7#.jpg" class="wx-qr medium-zoom-image"> |
-|    南科大行政服务中心    |    SUSTC-ASC    | <img src="https://open.weixin.qq.com/qr/code?username=SUSTC-ASC#.jpg" class="wx-qr medium-zoom-image"> |
-| 南科大后勤服务 | campusop | <img src="https://open.weixin.qq.com/qr/code?username=campusop#.jpg" class="wx-qr medium-zoom-image"> |
+|    南科大就业指导中心    | SUSTech_careercenter | <img src="https://open.weixin.qq.com/qr/code?username=SUSTech_careercenter#.jpg" class="wx-qr medium-zoom-image"> |
+|    南科大国际合作部    | gh_dd1dfb00b9db | <img src="https://open.weixin.qq.com/qr/code?username=gh_dd1dfb00b9db#.jpg" class="wx-qr medium-zoom-image"> |
+|    南科大行政服务中心    |    Sustech-ASC    | <img src="https://open.weixin.qq.com/qr/code?username=Sustech-ASC#.jpg" class="wx-qr medium-zoom-image"> |
 | 南科大总务君 | campusoperation | <img src="https://open.weixin.qq.com/qr/code?username=campusoperation#.jpg" class="wx-qr medium-zoom-image"> |
 
 
@@ -68,7 +67,7 @@ img.wx-qr.medium-zoom-image{ min-width: 100px; max-width: 150px; }
 | :----------------------: | :-------------: | :----------------------------------------------------------: |
 | 南科大信息平台（学生会） |   SUSTC_Info    | <img src="https://open.weixin.qq.com/qr/code?username=SUSTC_Info#.jpg" class="wx-qr medium-zoom-image"> |
 |    南科新知（新闻社）    | gh_db61459fa255 | <img src="https://open.weixin.qq.com/qr/code?username=gh_db61459fa255#.jpg" class="wx-qr medium-zoom-image"> |
-|    南科大义工联    | SUSTC_Volunteers | <img src="https://open.weixin.qq.com/qr/code?username=SUSTC_Volunteers#.jpg" class="wx-qr medium-zoom-image"> |
+|    南科大义工联    | SUSTech_Volunteers | <img src="https://open.weixin.qq.com/qr/code?username=SUSTech_Volunteers#.jpg" class="wx-qr medium-zoom-image"> |
 
 ## 自媒体
 
@@ -83,10 +82,10 @@ img.wx-qr.medium-zoom-image{ min-width: 100px; max-width: 150px; }
 | 少爷和陈老师 | gh_907391e11ad8 | （院长的）个人习作练习本 | <img src="https://open.weixin.qq.com/qr/code?username=gh_907391e11ad8#.jpg" class="wx-qr medium-zoom-image"> |
 | [你科周末](https://sustc.wiki/你科周末) | joydiet | 扎根妮可的野生周末菌。 | <img src="https://open.weixin.qq.com/qr/code?username=joydiet#.jpg" class="wx-qr medium-zoom-image"> |
 | [南科先知](https://sustc.wiki/南科先知) | gh_189f9ac8413e | 在这里读懂南科。 | <img src="https://open.weixin.qq.com/qr/code?username=gh_189f9ac8413e#.jpg" class="wx-qr medium-zoom-image"> |
-| 南科每日见闻 | sustechdailynews | 南科每日见闻致力于打造南科大洋葱新闻的频道，读者却发现里面大实话比假新闻还多，感人至深。 | <img src="https://open.weixin.qq.com/qr/code?username=sustechdailynews#.jpg" class="wx-qr medium-zoom-image"> |
+| ~~南科每日见闻~~ | sustechdailynews | 南科每日见闻致力于打造南科大洋葱新闻的频道，读者却发现里面大实话比假新闻还多，感人至深。 | <img src="https://open.weixin.qq.com/qr/code?username=sustechdailynews#.jpg" class="wx-qr medium-zoom-image"> |
 | LGBT在南科 | SUSTC_LGBT | 把LGBT在南科分享到南科大家长群，家长马上就不愿意了：“南科大这么多同性恋？还得开个号？”他们实在是跟不上潮流了，家长就该知道，这个公众号的粉丝里，腐女比基佬还多！ | <img src="https://open.weixin.qq.com/qr/code?username=SUSTC_LGBT#.jpg" class="wx-qr medium-zoom-image"> |
 | 南科大表白墙 | gh_6fe1a8d532fa | 有些人没人爱，只能去南科大表白墙给心爱的人表白。一看这阅读量，你说一没人爱的表白墙，你还指望它保佑你？ | <img src="https://open.weixin.qq.com/qr/code?username=gh_6fe1a8d532fa#.jpg" class="wx-qr medium-zoom-image"> |
-| [南科数据](https://sustc.wiki/index.php?title=南科数据&action=edit&redlink=1) | SUSTech-data | 南科数据用7个人的工作量，完成了串串1个人的推文效果；调查了南科大三千人的生活数据，获得了一百来个阅读量。 | <img src="https://open.weixin.qq.com/qr/code?username=SUSTech-data#.jpg" class="wx-qr medium-zoom-image"> |
+| ~~[南科数据](https://sustc.wiki/index.php?title=南科数据&action=edit&redlink=1)~~ | SUSTech-data | 南科数据用7个人的工作量，完成了串串1个人的推文效果；调查了南科大三千人的生活数据，获得了一百来个阅读量。 | <img src="https://open.weixin.qq.com/qr/code?username=SUSTech-data#.jpg" class="wx-qr medium-zoom-image"> |
 | MH的情诗 | gh_56faa346030c | MH的情诗从来没有写过情诗，都是他自己写给自己的，蛮不容易的小伙子，里面有自拍，赏脸进去找找吧。 | <img src="https://open.weixin.qq.com/qr/code?username=gh_56faa346030c#.jpg" class="wx-qr medium-zoom-image"> |
 | BelleEau | belleeau | BelleEau用了个法语名字，在这么多表里不一的公众号群体里，这是难得的名字和内容如此一致的，都像靡靡之音。这个法语名字音译成白露，太矫情，就该叫：水得漂亮。顺便一提，目前的公众号文章作者叫做[枫丹](https://sustc.wiki/枫丹) 。 |<img src="https://open.weixin.qq.com/qr/code?username=belleeau#.jpg" class="wx-qr medium-zoom-image"> |
 | StudioGlorire | studiogloire | StudioGloire见证了冯小漠从白手起家到过气网红的宝贵青春年华。难得的一个坚守文字气息没有蹭热度的公众号，然后果然也没啥人看。 | <img src="https://open.weixin.qq.com/qr/code?username=studiogloire#.jpg" class="wx-qr medium-zoom-image"> |
@@ -99,15 +98,15 @@ img.wx-qr.medium-zoom-image{ min-width: 100px; max-width: 150px; }
 | 草莓味大侠 | gh_3b8708014fed | 不要关注草莓味大侠，因为这个公众号号主对待推文如对待qq空间的说说一样。当然，评论区也是这样。别浪费时间了。 | <img src="https://open.weixin.qq.com/qr/code?username=gh_3b8708014fed#.jpg" class="wx-qr medium-zoom-image"> |
 | 巧克力琼脂 | gh_1f42309c3eee | 巧克力琼脂发挥强大的文言文功底，全文分析了著名的《诸葛亮骂死王司徒》，成功把已经红遍大江南北的名文又搞冷场了。 | <img src="https://open.weixin.qq.com/qr/code?username=gh_1f42309c3eee#.jpg" class="wx-qr medium-zoom-image"> |
 | 徵羽 | zy170504 | 徵羽 非常有 成为一个诗人 的潜质 特别是喜欢 把一段话 分行 | <img src="https://open.weixin.qq.com/qr/code?username=zy170504#.jpg" class="wx-qr medium-zoom-image"> |
-| 没有墨水 | myms-wanan | 微信公众号服务能有力地推进文化大发展大繁荣，什么小学生作文都能往上放。 | <img src="https://open.weixin.qq.com/qr/code?username=myms-wanan#.jpg" class="wx-qr medium-zoom-image"> |
+| ~~没有墨水~~ | myms-wanan | 微信公众号服务能有力地推进文化大发展大繁荣，什么小学生作文都能往上放。 | <img src="https://open.weixin.qq.com/qr/code?username=myms-wanan#.jpg" class="wx-qr medium-zoom-image"> |
 | FishmanInFishland | gh_b13ae4ee27df | FISH是一个行为艺术家，曾经他想做一个“一夜蹿红”的行为艺术，没成功，后来他要做一个“退出江湖”。成功了。 | <img src="https://open.weixin.qq.com/qr/code?username=gh_b13ae4ee27df#.jpg" class="wx-qr medium-zoom-image"> |
 | 二十七号病床 | gh_f9504b1ff650 | 一个曾经做日历失败了，然后转行做3D打印硬糖的老板娘… | <img src="https://open.weixin.qq.com/qr/code?username=gh_f9504b1ff650#.jpg" class="wx-qr medium-zoom-image"> |
 | 只允许含有中文英文数字 | gh_624f22da5bd3 | 如果一个公众号的关注量有负数，那么一定属于一个讲数学问题的公众号。 | <img src="https://open.weixin.qq.com/qr/code?username=gh_624f22da5bd3#.jpg" class="wx-qr medium-zoom-image"> |
 | Scheddi的小世界 | gh_71b51070297a | 这位德语名字的小世界，一直在等待插图，这是个小到没有插图的世界。 | <img src="https://open.weixin.qq.com/qr/code?username=gh_71b51070297a#.jpg" class="wx-qr medium-zoom-image"> |
 | 过饱和醋酸钠溶液 | supersaturatedNaAc | 过饱和醋酸钠是一种没有醋酸的酸味，也没有别的钠盐好用的东西。说明至少有一个优点，就是对自己的号定位准确。 | <img src="https://open.weixin.qq.com/qr/code?username=supersaturatedNaAc#.jpg" class="wx-qr medium-zoom-image"> |
-| [南科危废](https://sustc.wiki/index.php?title=南科危废&action=edit&redlink=1) | wefailed | 它就像它的微信号说的那样。 | <img src="https://open.weixin.qq.com/qr/code?username=wefailed#.jpg" class="wx-qr medium-zoom-image"> |
+| ~~[南科危废](https://sustc.wiki/index.php?title=南科危废&action=edit&redlink=1)~~ | wefailed | 它就像它的微信号说的那样。 | <img src="https://open.weixin.qq.com/qr/code?username=wefailed#.jpg" class="wx-qr medium-zoom-image"> |
 | 川哥沙雕搬运 | shadiaochuan | 这是一个不定期搬运沙雕图、推荐电影、甚至小编还会自掏腰包请大家免费听歌的公众号。 | <img src="https://open.weixin.qq.com/qr/code?username=shadiaochuan#.jpg" class="wx-qr medium-zoom-image"> |
-| 黑色肥肠 | HSFC1997 | 喜欢在寂寥无人、蠢蠢欲动的夜晚进行一些单身狗式的过度思考。 | <img src="https://open.weixin.qq.com/qr/code?username=HSFC1997#.jpg" class="wx-qr medium-zoom-image"> |
+| ~~黑色肥肠~~ | HSFC1997 | 喜欢在寂寥无人、蠢蠢欲动的夜晚进行一些单身狗式的过度思考。 | <img src="https://open.weixin.qq.com/qr/code?username=HSFC1997#.jpg" class="wx-qr medium-zoom-image"> |
 | ~~[啵闻](https://sustc.wiki/index.php?title=啵闻&action=edit&redlink=1)~~ | sustechbowen | 知道了自己保研消息的博姥爷干了两件事情：一个是感谢自己的导师，还有一个是开了这个公众号吹牛。看着啵宝就像看时尚杂志——月入5k的人，教月入2k的人怎么过月入2w的生活。 | <img src="https://open.weixin.qq.com/qr/code?username=sustechbowen#.jpg" class="wx-qr medium-zoom-image"> |
 | ~~南科周末~~ | DeltaLeo | 南科周末正在努力学习UC浏览器的技术，特别是如何不要脸地抄袭别人的头条。 | <img src="https://open.weixin.qq.com/qr/code?username=DeltaLeo#.jpg" class="wx-qr medium-zoom-image"> |
 


### PR DESCRIPTION
树仁书院 公众号已转移至gh_d955765a8692
南科大招生 公众号修改id为gotosustech
南科大就业指导中心 公众号修改id为SUSTech_careercenter
南科大国际合作部 公众号已转移至gh_dd1dfb00b9db
南科大行政服务中心 公众号修改id为Sustech-ASC 
南科大义工联 公众号修改id为SUSTech_Volunteers 
南科大行政服务中心 公众号已合并至 南科大总务君

南科每日见闻 公众号已注销
南科数据 公众号已注销
没有墨水 公众号已注销
南科危废 公众号已注销
黑色肥肠 公众号已注销