### PR TITLE
更新Office 365存储空间

### DIFF
--- a/docs/service/README.md
+++ b/docs/service/README.md
@@ -105,7 +105,7 @@
 ### 教育邮箱福利
 
 1. [Office 365](https://signup.microsoft.com/signup?sku=Education)
-   * 仅有 Office online 套件，OneDrive 1TB 等
+   * 仅有 Office online 套件，OneDrive ~~1TB~~ 100GB 等
    * 不含 桌面版 Office 365 许可
 2. [Jetbrains 全家桶](https://www.jetbrains.com/zh/student/)
    - 包含JetBarins旗下软件的教育授权


### PR DESCRIPTION
根据https://www.microsoft.com/en-us/education/products/microsoft-365-storage-options ，Office 365的机构存储空间改为100GB而不是之前的1TB了