### PR TITLE
新增讲座 《科学大讲堂 第249期》Yingying Fan 教授：Model-X knockoffs框架及其稳健性 - 2026-06-26 07:59

### DIFF
--- a/docs/study/talks/2026-06-26T11-00-00_Yingying_Fan.md
+++ b/docs/study/talks/2026-06-26T11-00-00_Yingying_Fan.md
@@ -1,10 +1,10 @@
-﻿# 《科学大讲堂 第249期》Prof. Yingying Fan：Model-X knockoffs框架及其稳健性
+﻿# 《科学大讲堂 第249期》Yingying Fan 教授：Model-X knockoffs框架及其稳健性
 
 > 以下内容根据公开信息整理，并经大模型处理生成，可能存在疏漏或误差，请以实际信息为准。
 
 
 * 题目: Model-X knockoffs框架及其稳健性
-* 主讲人：Prof. Yingying Fan @ 南加州大学
+* 主讲人：Yingying Fan 教授 @ 南加州大学
 * 时间：2026年6月26日 11:00-12:00
 * 地点：理学院一楼1142报告厅
 

--- a/docs/study/talks/README.md
+++ b/docs/study/talks/README.md
@@ -10,7 +10,7 @@
 
 ## 2026-06-26 周五
 
-- 11:00 - [《科学大讲堂 第249期》Prof. Yingying Fan：Model-X knockoffs框架及其稳健性](2026-06-26T11-00-00_Yingying_Fan.md)
+- 11:00 - [《科学大讲堂 第249期》Yingying Fan 教授：Model-X knockoffs框架及其稳健性](2026-06-26T11-00-00_Yingying_Fan.md)
 
 ## 2026-06-22 周一
 

--- a/docs/study/talks/talks-wx.md
+++ b/docs/study/talks/talks-wx.md
@@ -15,7 +15,7 @@ navbar: false
 
 ## 2026-06-26 周五
 
-- 11:00 - [《科学大讲堂 第249期》Prof. Yingying Fan：Model-X knockoffs框架及其稳健性](2026-06-26T11-00-00_Yingying_Fan.md)
+- 11:00 - [《科学大讲堂 第249期》Yingying Fan 教授：Model-X knockoffs框架及其稳健性](2026-06-26T11-00-00_Yingying_Fan.md)
 
 ## 2026-06-22 周一
 


### PR DESCRIPTION
本次更新以下讲座：

- **《科学大讲堂 第249期》Yingying Fan 教授：Model-X knockoffs框架及其稳健性** - Yingying Fan.md (2026:06:26 11-00-00)