### PR TITLE
新增讲座 《科学大讲堂 第253期》Prof. Gernot Frenking：主族化合物的配位键 - 2026-07-15 14:46

### DIFF
--- a/docs/study/talks/2026-07-17T16-00-00_Gernot_Frenking.md
+++ b/docs/study/talks/2026-07-17T16-00-00_Gernot_Frenking.md
@@ -9,13 +9,10 @@
 * 地点：理学院一楼化学系C1038报告厅
 
 ## 主讲人简介
-Academic Career
-1969 – 1973: Studying chemistry at the Technical University Aachen; 1974 – 1976: Research student in the group of Prof. Kenichi Fukui in Kyoto (Japan); 1976 – 1979: Doctoral work at the Technical University Berlin; 1979 – 1984: Habilitation at the Technical University Berlin; 1984 – 1985: Visiting scientist at the University of California, Berkeley; 1985 – 1989: Staff scientist at SRI International in Menlo Park, California; 1990 – 1998: C3(Associate)-Professor for Computational Chemistry at the Philipps-Universität Marburg; 1998 – 2014: C4(Full)-Professor for Theoretical Chemistry at the Philipps-Universität Marburg;2014 – Professor Emeritus at the Philipps-Universität Marburg; 2015 – Ikerbasque Visiting Research Professor at the DIPC (Donostia International Physics Center) at Donostia-San Sebastian, Spain; 2017 – 2025: Research Professor at Nanjing Tech University, Nanjing, China.
-Honors/Awards
-1973: Scholarship of the Japanese Ministry of Education;1983 Liebig-Stipendium, Fonds der Chemischen Industrie; 1998: QCPE Lecture, University of Indiana, Bloomington; 2003: Charles A. Coulson Lecture, Center for Computational Chemistry; 2007: Elhuyar-Goldschmidt Prize of the Royal Society of Chemistry of Spain; 2008: Appointed Member of the Royal Society of Chemistry; 2009: Schrödinger Medal of the WATOC (World Association of Theoretical and Computational Chemists); 2010: The Hofmann Distinguished Lecture, Imperial College, London; 2011: Lise-Meitner Lecture, The Hebrew University of Jerusalem, Israel; 2012: Appointed Hans-Hellmann Professor, Philipps-Universität Marburg; 2016: Honorary Professorship of Nanjing Tech University; 2019: International Solvay Chair in Chemistry 2019, International Solvay Institutes, Brussels; 2020: Erich-Hückel Award of the GDCh (Gesellschaft Deutscher Chemiker).
+暂无简介
 
 ## 讲座简介
-The lecture focuses on the concept of dative bonding A→B where both electrons are donated from fragment A for the formation of the covalent bond. In contrast, in the electron-sharing variant of the covalent bond A-B each of the two components, A and B, contributes one electron. Distinguishing between the two bonding models is, for example, very helpful in describing the bond in carbon monoxide C≡O, which is a physically more reasonable picture than using charged atoms C-O+ that was suggested by Pauling. Dative bonding nicely explains why carbon suboxide C3O2 has a bent geometry with a bending angle of 169° where the central C atom is a divalent C(0) which bind two CO ligands (OC)→C←(CO), which is a member of the class of carbones CL2. Complexes with dative bonds are not restricted to carbon as central bond. There are other systems EL2 and complexes with two and three central moieties E2L2 and E3L3 (s. below). Recent experimental and theoretical work was carried out on heteroleptic carbones L1→C←L2 and borylones L1→B(R)←L2 and on dinitrogen complexes N2L2 with L = N2 as most prominent example N6.
+暂无摘要
 
 ## 海报链接
 ![](https://gtimg.liziwl.cn/post-img/2026-07-17T16-00-00_Gernot_Frenking.jpg)


### PR DESCRIPTION
本次更新以下讲座：

- **《科学大讲堂 第253期》Prof. Gernot Frenking：主族化合物的配位键** - Gernot Frenking.md (2026:07:17 16-00-00)